### PR TITLE
Add amqp operations

### DIFF
--- a/app/src/main/java/com/cesar/knot_thing_lib_android/MainActivity.kt
+++ b/app/src/main/java/com/cesar/knot_thing_lib_android/MainActivity.kt
@@ -7,8 +7,10 @@ import com.cesar.knot_sdk.KNoTAMQPFactory
 import com.cesar.knot_sdk.KNoTMessager
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
+import com.cesar.knot_sdk.knot_messages.KNoTMessageAuth
 import kotlinx.android.synthetic.main.activity_main.register_button
 import kotlinx.android.synthetic.main.activity_main.unregister_button
+import kotlinx.android.synthetic.main.activity_main.authenticate_button
 import org.jetbrains.anko.doAsync
 
 class MainActivity : AppCompatActivity() {
@@ -18,6 +20,7 @@ class MainActivity : AppCompatActivity() {
     val PASSWORD = "pass"
     val THING_ID = "a74151d19de59cd3"
     val THING_NAME = "thing-name"
+    val THING_TOKEN = "ejfhwekhrui234huirh23uf"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -27,6 +30,7 @@ class MainActivity : AppCompatActivity() {
         KNoTAMQPFactory().create(knotAMQP)
         val knotThingRegister = KNoTMessageRegister(THING_ID, THING_NAME)
         val knotThingUnregister = KNoTMessageUnregister(THING_ID)
+        val knotThingAuth = KNoTMessageAuth(THING_ID, THING_TOKEN)
 
         register_button.setOnClickListener {
             doAsync { knotMessager.register(knotThingRegister) }
@@ -35,5 +39,10 @@ class MainActivity : AppCompatActivity() {
         unregister_button.setOnClickListener {
             doAsync { knotMessager.unregister(knotThingUnregister) }
         }
+
+        authenticate_button.setOnClickListener {
+            doAsync { knotMessager.authenticate(knotThingAuth) }
+        }
+
     }
 }

--- a/app/src/main/java/com/cesar/knot_thing_lib_android/MainActivity.kt
+++ b/app/src/main/java/com/cesar/knot_thing_lib_android/MainActivity.kt
@@ -1,0 +1,32 @@
+package com.cesar.knot_thing_lib_android
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import com.cesar.knot_sdk.KNoTAMQP
+import com.cesar.knot_sdk.KNoTAMQPFactory
+import com.cesar.knot_sdk.KNoTMessager
+import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
+import kotlinx.android.synthetic.main.activity_main.register_button
+import org.jetbrains.anko.doAsync
+
+class MainActivity : AppCompatActivity() {
+    val HOSTNAME = "0.0.0.0"
+    val PORT_NUMBER = 5672
+    val USERNAME = "user"
+    val PASSWORD = "pass"
+    val THING_ID = "a74151d19de59cd3"
+    val THING_NAME = "thing-name"
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        val knotAMQP = KNoTAMQP(USERNAME, PASSWORD, HOSTNAME, PORT_NUMBER)
+        lateinit var knotMessager : KNoTMessager
+        KNoTAMQPFactory().create(knotAMQP)
+        val knotThingRegister = KNoTMessageRegister(THING_ID, THING_NAME)
+
+        register_button.setOnClickListener {
+            doAsync { knotMessager.register(knotThingRegister) }
+        }
+    }
+}

--- a/app/src/main/java/com/cesar/knot_thing_lib_android/MainActivity.kt
+++ b/app/src/main/java/com/cesar/knot_thing_lib_android/MainActivity.kt
@@ -6,7 +6,9 @@ import com.cesar.knot_sdk.KNoTAMQP
 import com.cesar.knot_sdk.KNoTAMQPFactory
 import com.cesar.knot_sdk.KNoTMessager
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
+import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
 import kotlinx.android.synthetic.main.activity_main.register_button
+import kotlinx.android.synthetic.main.activity_main.unregister_button
 import org.jetbrains.anko.doAsync
 
 class MainActivity : AppCompatActivity() {
@@ -24,9 +26,14 @@ class MainActivity : AppCompatActivity() {
         lateinit var knotMessager : KNoTMessager
         KNoTAMQPFactory().create(knotAMQP)
         val knotThingRegister = KNoTMessageRegister(THING_ID, THING_NAME)
+        val knotThingUnregister = KNoTMessageUnregister(THING_ID)
 
         register_button.setOnClickListener {
             doAsync { knotMessager.register(knotThingRegister) }
+        }
+
+        unregister_button.setOnClickListener {
+            doAsync { knotMessager.unregister(knotThingUnregister) }
         }
     }
 }

--- a/app/src/main/java/com/cesar/knot_thing_lib_android/MainActivity.kt
+++ b/app/src/main/java/com/cesar/knot_thing_lib_android/MainActivity.kt
@@ -13,10 +13,13 @@ import com.cesar.knot_sdk.KNoTTypes.KNOT_UNIT_NOT_APPLICABLE
 import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_BOOL
 import com.cesar.knot_sdk.knot_data.KNoTSchema
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateSchema
+import com.cesar.knot_sdk.knot_messages.KNoTMessageDataItem
+import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateData
 import kotlinx.android.synthetic.main.activity_main.register_button
 import kotlinx.android.synthetic.main.activity_main.unregister_button
 import kotlinx.android.synthetic.main.activity_main.authenticate_button
 import kotlinx.android.synthetic.main.activity_main.schema_update_button
+import kotlinx.android.synthetic.main.activity_main.data_publish_button
 import org.jetbrains.anko.doAsync
 
 class MainActivity : AppCompatActivity() {
@@ -49,7 +52,18 @@ class MainActivity : AppCompatActivity() {
             )
         )
 
-        val kNoTThingUpdateSchema = KNoTMessageUpdateSchema(THING_ID, knotThingSchema)
+        val knotThingUpdateSchema = KNoTMessageUpdateSchema(THING_ID, knotThingSchema)
+
+
+        val dataItem = object {
+            val sensorId : Int = SENSOR_ID
+            var value : Boolean = true
+        }
+
+        val knotData = mutableListOf(
+            KNoTMessageDataItem(dataItem)
+        )
+        val knotThingUpdateData = KNoTMessageUpdateData(THING_ID, knotData)
 
         register_button.setOnClickListener {
             doAsync { knotMessager.register(knotThingRegister) }
@@ -64,7 +78,11 @@ class MainActivity : AppCompatActivity() {
         }
 
         schema_update_button.setOnClickListener {
-            doAsync { knotMessager.updateSchema(kNoTThingUpdateSchema) }
+            doAsync { knotMessager.updateSchema(knotThingUpdateSchema) }
+        }
+
+        data_publish_button.setOnClickListener {
+            doAsync { knotMessager.publishData(knotThingUpdateData) }
         }
 
     }

--- a/app/src/main/java/com/cesar/knot_thing_lib_android/MainActivity.kt
+++ b/app/src/main/java/com/cesar/knot_thing_lib_android/MainActivity.kt
@@ -8,9 +8,15 @@ import com.cesar.knot_sdk.KNoTMessager
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageAuth
+import com.cesar.knot_sdk.KNoTTypes.KNOT_TYPE_ID_SWITCH
+import com.cesar.knot_sdk.KNoTTypes.KNOT_UNIT_NOT_APPLICABLE
+import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_BOOL
+import com.cesar.knot_sdk.knot_data.KNoTSchema
+import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateSchema
 import kotlinx.android.synthetic.main.activity_main.register_button
 import kotlinx.android.synthetic.main.activity_main.unregister_button
 import kotlinx.android.synthetic.main.activity_main.authenticate_button
+import kotlinx.android.synthetic.main.activity_main.schema_update_button
 import org.jetbrains.anko.doAsync
 
 class MainActivity : AppCompatActivity() {
@@ -21,6 +27,8 @@ class MainActivity : AppCompatActivity() {
     val THING_ID = "a74151d19de59cd3"
     val THING_NAME = "thing-name"
     val THING_TOKEN = "ejfhwekhrui234huirh23uf"
+    val SENSOR_ID = 1
+    val SENSOR_NAME = "updateSchemaTest"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,6 +39,17 @@ class MainActivity : AppCompatActivity() {
         val knotThingRegister = KNoTMessageRegister(THING_ID, THING_NAME)
         val knotThingUnregister = KNoTMessageUnregister(THING_ID)
         val knotThingAuth = KNoTMessageAuth(THING_ID, THING_TOKEN)
+        val knotThingSchema = mutableListOf(
+            KNoTSchema(
+                SENSOR_ID,
+                KNOT_VALUE_TYPE_BOOL,
+                KNOT_UNIT_NOT_APPLICABLE,
+                KNOT_TYPE_ID_SWITCH,
+                SENSOR_NAME
+            )
+        )
+
+        val kNoTThingUpdateSchema = KNoTMessageUpdateSchema(THING_ID, knotThingSchema)
 
         register_button.setOnClickListener {
             doAsync { knotMessager.register(knotThingRegister) }
@@ -42,6 +61,10 @@ class MainActivity : AppCompatActivity() {
 
         authenticate_button.setOnClickListener {
             doAsync { knotMessager.authenticate(knotThingAuth) }
+        }
+
+        schema_update_button.setOnClickListener {
+            doAsync { knotMessager.updateSchema(kNoTThingUpdateSchema) }
         }
 
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/register_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/register_label"
+        android:layout_gravity="center" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,4 +17,12 @@
         android:text="@string/unregister_label"
         android:layout_gravity="center" />
 
+    <Button
+        android:id="@+id/authenticate_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/auth_label"
+        android:layout_gravity="center" />
+
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,5 +24,11 @@
         android:text="@string/auth_label"
         android:layout_gravity="center" />
 
+    <Button
+        android:id="@+id/schema_update_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/schema_update_label"
+        android:layout_gravity="center" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,4 +10,11 @@
         android:text="@string/register_label"
         android:layout_gravity="center" />
 
+    <Button
+        android:id="@+id/unregister_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/unregister_label"
+        android:layout_gravity="center" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,4 +31,11 @@
         android:text="@string/schema_update_label"
         android:layout_gravity="center" />
 
+    <Button
+        android:id="@+id/data_publish_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/publish_label"
+        android:layout_gravity="center" />
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="unregister_label">send-unregister-message</string>
     <string name="auth_label">send-auth-message</string>
     <string name="schema_update_label">send-schema-update-message</string>
+    <string name="publish_label">send-data-message</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">knot-thing-lib-android</string>
     <string name="register_label">send-register-message</string>
+    <string name="unregister_label">send-unregister-message</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">knot-thing-lib-android</string>
     <string name="register_label">send-register-message</string>
     <string name="unregister_label">send-unregister-message</string>
+    <string name="auth_label">send-auth-message</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="register_label">send-register-message</string>
     <string name="unregister_label">send-unregister-message</string>
     <string name="auth_label">send-auth-message</string>
+    <string name="schema_update_label">send-schema-update-message</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">knot-thing-lib-android</string>
+    <string name="register_label">send-register-message</string>
 </resources>

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQP.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQP.kt
@@ -26,6 +26,7 @@ class KNoTAMQP(username : String, password : String, hostname : String, port : I
     val EXCHANGE_NAME_FOG = "fog"
 
     val BINDING_KEY_REGISTER = "device.register"
+    val BINDING_KEY_UNREGISTER = "device.unregister"
 
     val QUEUE_NAME_FOG_IN = "fogIn"
     val QUEUE_NAME_FOG_OUT = "fogOut"

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQP.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQP.kt
@@ -1,0 +1,143 @@
+package com.cesar.knot_sdk
+
+import com.rabbitmq.client.AMQP
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.Connection
+import com.rabbitmq.client.ConnectionFactory
+import java.io.IOException
+
+
+/**
+ * This class is an abstraction over the rabbitMQ java library it handles all
+ * AMQP specific operations, such as creation of connection, queues and
+ * consumers.
+ * This class contains all KNoT-Protocol specific keywords, such as, the binding
+ * keys and queue/consumer names.
+ * @param username the rabbitMQ username in the connector
+ * @param password the rabbitMQ password in the connector
+ * @param hostname the ip of the server running the connector
+ * @param port the port that rabbitMQ will be listening to (by default 5672)
+ */
+class KNoTAMQP(username : String, password : String, hostname : String, port : Int) {
+
+    val EXCHANGE_TYPE_TOPIC = "topic"
+
+    val EXCHANGE_NAME_CLOUD = "cloud"
+    val EXCHANGE_NAME_FOG = "fog"
+
+    val BINDING_KEY_REGISTER = "device.register"
+
+    val QUEUE_NAME_FOG_IN = "fogIn"
+    val QUEUE_NAME_FOG_OUT = "fogOut"
+
+    val connectionFactory = ConnectionFactory()
+
+    lateinit var conn : Connection
+    lateinit var channel : Channel
+
+    init {
+        connectionFactory.host = hostname
+        connectionFactory.username = username
+        connectionFactory.password = password
+        connectionFactory.port = port
+    }
+
+    /**
+     * Starts the connection with the rabbitMQ server. Uses the parameters
+     * defined in factory. Should not be executed in the main thread as it
+     * performs network operations.
+     */
+    fun startConnection() {
+        conn = connectionFactory.newConnection()
+        channel = conn.createChannel()
+    }
+
+    /**
+     * Creates an durable exchange with the name and type given in the
+     * parametes.
+     * @param exchangeName the name of the exchange
+     * @param exchangeType the type of the exchange
+     */
+    fun createExchange(
+        exchangeName : String,
+        exchangeType : String = EXCHANGE_TYPE_TOPIC) {
+
+        val exchangeException = "Something went wrong while creating this " +
+                "exchange: $exchangeName. Please try again, later."
+
+        val res = channel.exchangeDeclare(
+            exchangeName,
+            exchangeType,
+            true
+        )
+        if (res !is AMQP.Exchange.DeclareOk) throw IOException(exchangeException)
+    }
+
+    /**
+     * Creates a durable, non-exclusive and non self-deleting queue without
+     * extra parameters with the given name.
+     * @param queueName the name of the queue, must be either fogIn or fogOut.
+     */
+    fun createQueue(queueName: String) {
+        val durable = true
+        val exclusive = false
+        val autoDelete = false
+        val arguments = null
+        channel.queueDeclare(
+            queueName,
+            durable,
+            exclusive,
+            autoDelete,
+            arguments
+        ).queue
+    }
+
+    /**
+     * Binds a queue to an exchange and a routing key. Both the queue and the
+     * exchange should already exist in the channel.
+     * @param queueName name of an existing queue
+     * @param exchangeName name of an existing exchange
+     * @param routingKey the name of the desired queue
+     */
+    fun bindQueue( queueName : String, exchangeName : String, routingKey: String) {
+        val queueException = "Something went wrong while binding this " +
+                "queue: $exchangeName. Please try again, later."
+        val res = channel.queueBind(queueName, exchangeName, routingKey)
+        if (res !is AMQP.Queue.BindOk) throw IOException(queueException)
+    }
+
+    /**
+     * Publishes a message, in the specified exchange with the specified routing
+     * key. The message being sent, should respect the KNoT Protocol, which
+     * means it should be a formatted JSON and the routing key and exchange
+     * should be the proper ones.
+     * @param message the message that is going to be sent
+     * @param exchange the exchange that will hold the message
+     * @param routingKey the routing key the message is associated with
+     */
+    fun publish(message : String, exchange : String, routingKey : String) {
+        val messageBodyBytes = message.toByteArray()
+        val messageProperties = AMQP.BasicProperties.Builder()
+            .deliveryMode(2)
+            .build()
+
+        channel.basicPublish(
+            exchange,
+            routingKey,
+            messageProperties,
+            messageBodyBytes
+        )
+    }
+
+    /**
+     * This method is responsible for releasing the resources used by the AMQP
+     * communication. This method should only be called when ending a connection
+     * (when there is no intention of publishing/consuming data). Ideally this
+     * method should only be called when the application is being destroyed.
+     */
+    fun disconnect() {
+            channel.close()
+            conn.close()
+    }
+
+}

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQP.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQP.kt
@@ -27,6 +27,7 @@ class KNoTAMQP(username : String, password : String, hostname : String, port : I
 
     val BINDING_KEY_REGISTER = "device.register"
     val BINDING_KEY_UNREGISTER = "device.unregister"
+    val BINDING_KEY_AUTHENTICATE = "device.cmd.auth"
 
     val QUEUE_NAME_FOG_IN = "fogIn"
     val QUEUE_NAME_FOG_OUT = "fogOut"

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQP.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQP.kt
@@ -29,6 +29,7 @@ class KNoTAMQP(username : String, password : String, hostname : String, port : I
     val BINDING_KEY_UNREGISTER = "device.unregister"
     val BINDING_KEY_AUTHENTICATE = "device.cmd.auth"
     val BINDING_KEY_SCHEMA_UPDATE = "schema.update"
+    val BINDING_KEY_DATA_PUBLISH = "data.publish"
 
     val QUEUE_NAME_FOG_IN = "fogIn"
     val QUEUE_NAME_FOG_OUT = "fogOut"

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQP.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQP.kt
@@ -28,6 +28,7 @@ class KNoTAMQP(username : String, password : String, hostname : String, port : I
     val BINDING_KEY_REGISTER = "device.register"
     val BINDING_KEY_UNREGISTER = "device.unregister"
     val BINDING_KEY_AUTHENTICATE = "device.cmd.auth"
+    val BINDING_KEY_SCHEMA_UPDATE = "schema.update"
 
     val QUEUE_NAME_FOG_IN = "fogIn"
     val QUEUE_NAME_FOG_OUT = "fogOut"

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPController.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPController.kt
@@ -2,6 +2,7 @@ package com.cesar.knot_sdk
 
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
+import com.cesar.knot_sdk.knot_messages.KNoTMessageAuth
 import com.google.gson.Gson
 
 /**
@@ -22,6 +23,14 @@ class KNoTAMQPController(val knotAMQP: KNoTAMQP) : KNoTMessager {
             Gson().toJson(knotThingUnregister),
             knotAMQP.EXCHANGE_NAME_CLOUD,
             knotAMQP.BINDING_KEY_UNREGISTER
+        )
+    }
+
+    override fun authenticate(knotMessageAuth: KNoTMessageAuth) {
+        knotAMQP.publish(
+            Gson().toJson(knotMessageAuth),
+            knotAMQP.EXCHANGE_NAME_CLOUD,
+            knotAMQP.BINDING_KEY_AUTHENTICATE
         )
     }
 

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPController.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPController.kt
@@ -3,6 +3,7 @@ package com.cesar.knot_sdk
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageAuth
+import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateSchema
 import com.google.gson.Gson
 
 /**
@@ -31,6 +32,14 @@ class KNoTAMQPController(val knotAMQP: KNoTAMQP) : KNoTMessager {
             Gson().toJson(knotMessageAuth),
             knotAMQP.EXCHANGE_NAME_CLOUD,
             knotAMQP.BINDING_KEY_AUTHENTICATE
+        )
+    }
+
+    override fun updateSchema(knotMessageSchema: KNoTMessageUpdateSchema) {
+        knotAMQP.publish(
+            Gson().toJson(knotMessageSchema),
+            knotAMQP.EXCHANGE_NAME_CLOUD,
+            knotAMQP.BINDING_KEY_SCHEMA_UPDATE
         )
     }
 

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPController.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPController.kt
@@ -1,0 +1,19 @@
+package com.cesar.knot_sdk
+
+import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
+import com.google.gson.Gson
+
+/**
+ * This class implements the KNoT-Protocol operations for AMQP.
+ */
+class KNoTAMQPController(val knotAMQP: KNoTAMQP) : KNoTMessager {
+
+    override fun register(knotThingRegister : KNoTMessageRegister) {
+        knotAMQP.publish(
+            Gson().toJson(knotThingRegister),
+            knotAMQP.EXCHANGE_NAME_CLOUD,
+            knotAMQP.BINDING_KEY_REGISTER
+        )
+    }
+
+}

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPController.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPController.kt
@@ -1,6 +1,7 @@
 package com.cesar.knot_sdk
 
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
+import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
 import com.google.gson.Gson
 
 /**
@@ -13,6 +14,14 @@ class KNoTAMQPController(val knotAMQP: KNoTAMQP) : KNoTMessager {
             Gson().toJson(knotThingRegister),
             knotAMQP.EXCHANGE_NAME_CLOUD,
             knotAMQP.BINDING_KEY_REGISTER
+        )
+    }
+
+    override fun unregister(knotThingUnregister : KNoTMessageUnregister) {
+        knotAMQP.publish(
+            Gson().toJson(knotThingUnregister),
+            knotAMQP.EXCHANGE_NAME_CLOUD,
+            knotAMQP.BINDING_KEY_UNREGISTER
         )
     }
 

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPController.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPController.kt
@@ -4,6 +4,7 @@ import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageAuth
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateSchema
+import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateData
 import com.google.gson.Gson
 
 /**
@@ -40,6 +41,14 @@ class KNoTAMQPController(val knotAMQP: KNoTAMQP) : KNoTMessager {
             Gson().toJson(knotMessageSchema),
             knotAMQP.EXCHANGE_NAME_CLOUD,
             knotAMQP.BINDING_KEY_SCHEMA_UPDATE
+        )
+    }
+
+    override fun publishData(knotMessageUpdateData: KNoTMessageUpdateData) {
+        knotAMQP.publish(
+            Gson().toJson(knotMessageUpdateData),
+            knotAMQP.EXCHANGE_NAME_CLOUD,
+            knotAMQP.BINDING_KEY_DATA_PUBLISH
         )
     }
 

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPFactory.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPFactory.kt
@@ -48,6 +48,12 @@ class KNoTAMQPFactory {
                 knotAMQP.BINDING_KEY_SCHEMA_UPDATE
             )
 
+            knotAMQP.bindQueue(
+                knotAMQP.QUEUE_NAME_FOG_IN,
+                knotAMQP.EXCHANGE_NAME_CLOUD,
+                knotAMQP.BINDING_KEY_DATA_PUBLISH
+            )
+
         }
     }
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPFactory.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPFactory.kt
@@ -1,0 +1,34 @@
+package com.cesar.knot_sdk
+
+import org.jetbrains.anko.doAsync
+
+/**
+ * The creation of the KNoTAMQP class depends on a series of complicated
+ * operations, some of which involve network operations. This class is
+ * responsible solely to ease the creation of KNoTAMQP instances.
+ */
+class KNoTAMQPFactory {
+
+    /**
+     * Configures the KNoT-AMQP instance.
+     * @param knotAMQP a non-configured instance of the KNoTAMQP class.
+     * @param callback a callback to return after the operations are done.
+     */
+    fun create(
+        knotAMQP : KNoTAMQP
+    ) {
+        doAsync {
+            knotAMQP.startConnection()
+            knotAMQP.createExchange(knotAMQP.EXCHANGE_NAME_CLOUD)
+            knotAMQP.createExchange(knotAMQP.EXCHANGE_NAME_FOG)
+            knotAMQP.createQueue(knotAMQP.QUEUE_NAME_FOG_IN)
+            knotAMQP.createQueue(knotAMQP.QUEUE_NAME_FOG_OUT)
+
+            knotAMQP.bindQueue(
+                knotAMQP.QUEUE_NAME_FOG_IN,
+                knotAMQP.EXCHANGE_NAME_CLOUD,
+                knotAMQP.BINDING_KEY_REGISTER
+            )
+        }
+    }
+}

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPFactory.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPFactory.kt
@@ -29,6 +29,12 @@ class KNoTAMQPFactory {
                 knotAMQP.EXCHANGE_NAME_CLOUD,
                 knotAMQP.BINDING_KEY_REGISTER
             )
+
+            knotAMQP.bindQueue(
+                knotAMQP.QUEUE_NAME_FOG_IN,
+                knotAMQP.EXCHANGE_NAME_CLOUD,
+                knotAMQP.BINDING_KEY_UNREGISTER
+            )
         }
     }
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPFactory.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPFactory.kt
@@ -35,6 +35,13 @@ class KNoTAMQPFactory {
                 knotAMQP.EXCHANGE_NAME_CLOUD,
                 knotAMQP.BINDING_KEY_UNREGISTER
             )
+
+            knotAMQP.bindQueue(
+                knotAMQP.QUEUE_NAME_FOG_IN,
+                knotAMQP.EXCHANGE_NAME_CLOUD,
+                knotAMQP.BINDING_KEY_AUTHENTICATE
+            )
+
         }
     }
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPFactory.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTAMQPFactory.kt
@@ -42,6 +42,12 @@ class KNoTAMQPFactory {
                 knotAMQP.BINDING_KEY_AUTHENTICATE
             )
 
+            knotAMQP.bindQueue(
+                knotAMQP.QUEUE_NAME_FOG_IN,
+                knotAMQP.EXCHANGE_NAME_CLOUD,
+                knotAMQP.BINDING_KEY_SCHEMA_UPDATE
+            )
+
         }
     }
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessager.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessager.kt
@@ -4,6 +4,7 @@ import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageAuth
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateSchema
+import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateData
 
 /**
  * This interface represents all operations that are available with the KNoT
@@ -32,5 +33,10 @@ interface KNoTMessager {
      * Updates the schema for a KNoT Thing in the cloud.
      */
     fun updateSchema(knotMessageSchema: KNoTMessageUpdateSchema)
+
+    /**
+     * Publishes data from a KNoT Thing in the cloud.
+     */
+    fun publishData(knotMessageUpdateData: KNoTMessageUpdateData)
 
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessager.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessager.kt
@@ -2,6 +2,7 @@ package com.cesar.knot_sdk
 
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
+import com.cesar.knot_sdk.knot_messages.KNoTMessageAuth
 
 /**
  * This interface represents all operations that are available with the KNoT
@@ -20,5 +21,10 @@ interface KNoTMessager {
      * Unregister a KNoT Thing in the cloud.
      */
     fun unregister(knotThingUnregister : KNoTMessageUnregister)
+
+    /**
+     * Authenticates a KNoT Thing in the cloud.
+     */
+    fun authenticate(knotMessageAuth: KNoTMessageAuth)
 
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessager.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessager.kt
@@ -1,6 +1,7 @@
 package com.cesar.knot_sdk
 
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
+import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
 
 /**
  * This interface represents all operations that are available with the KNoT
@@ -14,5 +15,10 @@ interface KNoTMessager {
      * Register a KNoT Thing in the cloud.
      */
     fun register(knotThingRegister : KNoTMessageRegister)
+
+    /**
+     * Unregister a KNoT Thing in the cloud.
+     */
+    fun unregister(knotThingUnregister : KNoTMessageUnregister)
 
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessager.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessager.kt
@@ -1,0 +1,18 @@
+package com.cesar.knot_sdk
+
+import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
+
+/**
+ * This interface represents all operations that are available with the KNoT
+ * protocol.
+ * Classes that implement this interface can use any kind of technology to send
+ * these messages (AMQP, WebSockets, etc), but should support these operations.
+ */
+interface KNoTMessager {
+
+    /**
+     * Register a KNoT Thing in the cloud.
+     */
+    fun register(knotThingRegister : KNoTMessageRegister)
+
+}

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessager.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessager.kt
@@ -3,6 +3,7 @@ package com.cesar.knot_sdk
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRegister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUnregister
 import com.cesar.knot_sdk.knot_messages.KNoTMessageAuth
+import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateSchema
 
 /**
  * This interface represents all operations that are available with the KNoT
@@ -26,5 +27,10 @@ interface KNoTMessager {
      * Authenticates a KNoT Thing in the cloud.
      */
     fun authenticate(knotMessageAuth: KNoTMessageAuth)
+
+    /**
+     * Updates the schema for a KNoT Thing in the cloud.
+     */
+    fun updateSchema(knotMessageSchema: KNoTMessageUpdateSchema)
 
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTTypes.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTTypes.kt
@@ -1,0 +1,132 @@
+package com.cesar.knot_sdk
+
+/**
+ * This is a collection of all supported KNoT types, units and values.
+ * This file is based on the knot_types.h file located at the KNoT Protocol
+ * repository https://github.com/CESARBR/knot-protocol-source.git from
+ * the commit cf3bf988efad3ca287d84a52a9085ee029eceb39.
+ */
+object KNoTTypes {
+    // definition of invalid sensor id
+    const val KNOT_SENSOR_ID_INVALID            =       0xFF
+
+    // TypeIDs for basic units
+    const val KNOT_TYPE_ID_NONE                 =       0x0000
+    const val KNOT_TYPE_ID_VOLTAGE              =       0x0001
+    const val KNOT_TYPE_ID_CURRENT              =       0x0002
+    const val KNOT_TYPE_ID_RESISTANCE           =       0x0003
+    const val KNOT_TYPE_ID_POWER                =       0x0004
+    const val KNOT_TYPE_ID_TEMPERATURE          =       0x0005
+    const val KNOT_TYPE_ID_RELATIVE_HUMIDITY    =       0x0006
+    const val KNOT_TYPE_ID_LUMINOSITY           =       0x0007
+    const val KNOT_TYPE_ID_TIME                 =       0x0008
+    const val KNOT_TYPE_ID_MASS                 =       0x0009
+    const val KNOT_TYPE_ID_PRESSURE             =       0x000A
+    const val KNOT_TYPE_ID_DISTANCE             =       0x000B
+    const val KNOT_TYPE_ID_ANGLE                =       0x000C
+    const val KNOT_TYPE_ID_VOLUME               =       0x000D
+    const val KNOT_TYPE_ID_AREA                 =       0x000E
+    const val KNOT_TYPE_ID_RAIN                 =       0x000F
+    const val KNOT_TYPE_ID_DENSITY              =       0x0010
+    const val KNOT_TYPE_ID_LATITUDE             =       0x0011
+    const val KNOT_TYPE_ID_LONGITUDE            =       0x0012
+    const val KNOT_TYPE_ID_SPEED                =       0x0013
+    const val KNOT_TYPE_ID_VOLUMEFLOW           =       0x0014
+    const val KNOT_TYPE_ID_ENERGY               =       0x0015
+
+    // MAX TypeID for basic units
+    const val KNOT_TYPE_ID_BASIC_MAX            =       KNOT_TYPE_ID_ENERGY + 1
+
+    // TypeIDs for logical units
+    const val KNOT_TYPE_ID_PRESENCE             =       0xFFF0
+    const val KNOT_TYPE_ID_SWITCH               =       0xFFF1
+    const val KNOT_TYPE_ID_COMMAND              =       0xFFF2
+
+    // MIN TypeID for logic units
+    const val KNOT_TYPE_ID_LOGIC_MIN            =       KNOT_TYPE_ID_PRESENCE
+    // MAX TypeID for logic units
+    const val KNOT_TYPE_ID_LOGIC_MAX            =       KNOT_TYPE_ID_COMMAND + 1
+
+    // TypeIDs for generic units
+    const val KNOT_TYPE_ID_ANALOG               =       0xFF10
+
+    // MIN TypeID for generic units
+    const val KNOT_TYPE_ID_GENERIC_MIN          =       KNOT_TYPE_ID_ANALOG
+    // MAX TypeID for generic units
+    const val KNOT_TYPE_ID_GENERIC_MAX          =       KNOT_TYPE_ID_ANALOG + 1
+
+    const val KNOT_TYPE_ID_INVALID              =       0xFFFF
+
+    // definition of measurement units
+    const val KNOT_UNIT_NOT_APPLICABLE          =       0x00
+    const val KNOT_UNIT_VOLTAGE_V               =       0x01
+    const val KNOT_UNIT_VOLTAGE_MV              =       0x02
+    const val KNOT_UNIT_VOLTAGE_KV              =       0x03
+    const val KNOT_UNIT_CURRENT_A               =       0x01
+    const val KNOT_UNIT_CURRENT_MA              =       0x02
+    const val KNOT_UNIT_RESISTANCE_OHM          =       0x01
+    const val KNOT_UNIT_POWER_W                 =       0x01
+    const val KNOT_UNIT_POWER_KW                =       0x02
+    const val KNOT_UNIT_POWER_MW                =       0x03
+    const val KNOT_UNIT_TEMPERATURE_C           =       0x01
+    const val KNOT_UNIT_TEMPERATURE_F           =       0x02
+    const val KNOT_UNIT_TEMPERATURE_K           =       0x03
+    const val KNOT_UNIT_RELATIVE_HUMIDITY       =       0x01
+    const val KNOT_UNIT_LUMINOSITY_LM           =       0x01
+    const val KNOT_UNIT_LUMINOSITY_CD           =       0x02
+    const val KNOT_UNIT_LUMINOSITY_LX           =       0x03
+    const val KNOT_UNIT_TIME_S                  =       0x01
+    const val KNOT_UNIT_TIME_MS                 =       0x02
+    const val KNOT_UNIT_TIME_US                 =       0x03
+    const val KNOT_UNIT_MASS_KG                 =       0x01
+    const val KNOT_UNIT_MASS_G                  =       0x02
+    const val KNOT_UNIT_MASS_LB                 =       0x03
+    const val KNOT_UNIT_MASS_OZ                 =       0x04
+    const val KNOT_UNIT_PRESSURE_PA             =       0x01
+    const val KNOT_UNIT_PRESSURE_PSI            =       0x02
+    const val KNOT_UNIT_PRESSURE_BAR            =       0x03
+    const val KNOT_UNIT_DISTANCE_M              =       0x01
+    const val KNOT_UNIT_DISTANCE_CM             =       0x02
+    const val KNOT_UNIT_DISTANCE_MI             =       0x03
+    const val KNOT_UNIT_DISTANCE_IN             =       0x04
+    const val KNOT_UNIT_ANGLE_RAD               =       0x01
+    const val KNOT_UNIT_ANGLE_DEGREE            =       0x02
+    const val KNOT_UNIT_VOLUME_L                =       0x01
+    const val KNOT_UNIT_VOLUME_ML               =       0x02
+    const val KNOT_UNIT_VOLUME_FLOZ             =       0x03
+    const val KNOT_UNIT_VOLUME_GAL              =       0x04
+    const val KNOT_UNIT_AREA_M2                 =       0x01
+    const val KNOT_UNIT_AREA_HA                 =       0x02
+    const val KNOT_UNIT_AREA_AC                 =       0x03
+    const val KNOT_UNIT_RAIN_MM                 =       0x01
+    const val KNOT_UNIT_DENSITY_KGM3            =       0x01
+    const val KNOT_UNIT_LATITUDE_DEGREE         =       0x01
+    const val KNOT_UNIT_LONGITUDE_DEGREE        =       0x01
+    const val KNOT_UNIT_SPEED_MS                =       0x01
+    const val KNOT_UNIT_SPEED_CMS               =       0x02
+    const val KNOT_UNIT_SPEED_KMH               =       0x03
+    const val KNOT_UNIT_SPEED_MIH               =       0x04
+    const val KNOT_UNIT_VOLUMEFLOW_M3S          =       0x01
+    const val KNOT_UNIT_VOLUMEFLOW_SCMM         =       0x02
+    const val KNOT_UNIT_VOLUMEFLOW_LS           =       0x03
+    const val KNOT_UNIT_VOLUMEFLOW_LM           =       0x04
+    const val KNOT_UNIT_VOLUMEFLOW_FT3S         =       0x05
+    const val KNOT_UNIT_VOLUMEFLOW_GALM         =       0x06
+    const val KNOT_UNIT_ENERGY_J                =       0x01
+    const val KNOT_UNIT_ENERGY_NM               =       0x02
+    const val KNOT_UNIT_ENERGY_WH               =       0x03
+    const val KNOT_UNIT_ENERGY_KWH              =       0x04
+    const val KNOT_UNIT_ENERGY_CAL              =       0x05
+    const val KNOT_UNIT_ENERGY_KCAL             =       0x06
+
+    // definition of value type
+    const val KNOT_VALUE_NULL                   =       0x00
+    const val KNOT_VALUE_TYPE_INT               =       0x01
+    const val KNOT_VALUE_TYPE_FLOAT             =       0x02
+    const val KNOT_VALUE_TYPE_BOOL              =       0x03
+    const val KNOT_VALUE_TYPE_RAW               =       0x04
+    const val KNOT_VALUE_TYPE_MIN               =       KNOT_VALUE_TYPE_INT
+    const val KNOT_VALUE_TYPE_MAX               =       KNOT_VALUE_TYPE_RAW + 1
+    const val KNOT_VALUE_TYPE_INVALID           =       0XFF
+
+}

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_data/KNoTSchema.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_data/KNoTSchema.kt
@@ -1,0 +1,18 @@
+package com.cesar.knot_sdk.knot_data
+
+/**
+ * This class is an abstraction for the meta-data of it's associated KNoTValue. For instance
+ * the value of an amperimeter could be in any unit (e.g.: Amperes, mili-amperes, ...).
+ *
+ * @property name the name of the sensor
+ * @property typeID the dimension being analyzed (e.g.: temperature, velocity, light, ...)
+ * @property unit represents the unit associated with this KNoTValue
+ * @property valueType the value type (e.g.: int, string, boolean ...)
+ */
+data class KNoTSchema(
+    val sensorId : Int,
+    val valueType : Int,
+    val unit : Int,
+    val typeId : Int,
+    val name : String
+)

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageAuth.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageAuth.kt
@@ -1,0 +1,11 @@
+package com.cesar.knot_sdk.knot_messages
+
+/**
+ * This is the class that is serialized as an authentication message.
+ * @property id the Thing unique identifier
+ * @property token the authentication token provided after registration
+ */
+data class KNoTMessageAuth(
+    val id : String,
+    val token : String
+)

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageDataItem.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageDataItem.kt
@@ -1,0 +1,10 @@
+package com.cesar.knot_sdk.knot_messages
+
+/**
+ * This is the class that is serialized for one data value, from one sensor.
+ * @property id the Thing unique identifier
+ * @property data the data batch that is to be sent
+ */
+data class KNoTMessageDataItem(
+    val value : Any
+)

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageRegister.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageRegister.kt
@@ -1,0 +1,15 @@
+package com.cesar.knot_sdk.knot_messages
+
+/**
+ * This class is an abstraction for the registration message. Its property names
+ * are already mapped to the expected values in the message JSON, which means
+ * it's really easy to convert these values to the expected JSON message.
+ * @property id a unique identifier for the Thing, be careful to not generate a
+ * duplicate name, as the KNoT-Protocol does not define what happens when
+ * receiving a duplicate id.
+ * @property name a string that represents this device in some manner.
+ */
+data class KNoTMessageRegister(
+    val id : String,
+    val name : String
+)

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageRegistered.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageRegistered.kt
@@ -1,0 +1,11 @@
+package com.cesar.knot_sdk.knot_messages
+
+/**
+ * This is the class that deserialize the response of the registration message.
+ * @property id the Thing unique identifier
+ * @property token the token received after registration
+ */
+data class KNoTMessageRegistered(
+    val id : String,
+    val token : String
+)

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageUnregister.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageUnregister.kt
@@ -1,0 +1,9 @@
+package com.cesar.knot_sdk.knot_messages
+
+/**
+ * This is the class that is serialized as an unregister message.
+ * @property id the Thing unique identifier
+ */
+data class KNoTMessageUnregister(
+    val id : String
+)

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageUpdateData.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageUpdateData.kt
@@ -1,0 +1,11 @@
+package com.cesar.knot_sdk.knot_messages
+
+/**
+ * This is the class that is serialized to update data values for all sensors.
+ * @property id the Thing unique identifier
+ * @property data a Pair of Int (sensorId) and Any (value).
+ */
+data class KNoTMessageUpdateData(
+    val id : String,
+    val data : List<KNoTMessageDataItem>
+)

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageUpdateSchema.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageUpdateSchema.kt
@@ -1,0 +1,13 @@
+package com.cesar.knot_sdk.knot_messages
+
+import com.cesar.knot_sdk.knot_data.KNoTSchema
+
+/**
+ * This is the class that is serialized to update the sensors schema.
+ * @property id the Thing unique identifier
+ * @property schema the Things schema
+ */
+data class KNoTMessageUpdateSchema(
+    val id : String,
+    val schema : List<KNoTSchema>
+)


### PR DESCRIPTION
This patch adds all operations used in the configuration progress of a Thing with the KNoT Cloud. As the patch name implies these operations were implemented using the AMQP protocol. 

Depends on #11 