### PR TITLE
Add parser for southbound operations

### DIFF
--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
@@ -8,6 +8,7 @@ import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_MAX
 import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_RAW
 import com.cesar.knot_sdk.knot_messages.KNoTMessageAuthenticated
 import com.cesar.knot_sdk.knot_messages.KNoTMessageDataItem
+import com.cesar.knot_sdk.knot_messages.KNoTMessageRegistered
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRequestData
 import com.cesar.knot_sdk.knot_messages.KNoTMessageSchemaResp
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateData
@@ -109,5 +110,14 @@ class KNoTMessageParser {
         val error = receivedJson.get(ERROR).toString()
 
         return KNoTMessageAuthenticated(id, error)
+    }
+
+    fun parseDeviceRegistered(knotRegister : String) : KNoTMessageRegistered {
+        val receivedJson = JsonParser.parseString(knotRegister).asJsonObject
+        val id = receivedJson.get(ID).asString
+        val token = receivedJson.get(TOKEN).toString()
+        val error = receivedJson.get(ERROR).toString()
+
+        return KNoTMessageRegistered(id, token, error)
     }
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
@@ -7,6 +7,7 @@ import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_INT
 import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_MAX
 import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_RAW
 import com.cesar.knot_sdk.knot_messages.KNoTMessageDataItem
+import com.cesar.knot_sdk.knot_messages.KNoTMessageRequestData
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateData
 import com.google.gson.JsonParser
 
@@ -20,6 +21,9 @@ class KNoTMessageParser {
     private val DATA = "data"
     private val ID = "id"
     private val SENSOR_ID = "sensorId"
+    private val SENSOR_IDS = "sensorIds"
+    private val TOKEN = "token"
+    private val ERROR = "error"
     private val ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE =
             "The KNoTMessageParser is only prepared to handle " +
             "KNOT_VALUE_TYPE_INT, KNOT_VALUE_TYPE_FLOAT, " +
@@ -74,5 +78,18 @@ class KNoTMessageParser {
         }
 
         return KNoTMessageUpdateData(id, data)
+    }
+
+    fun parseDataRequest(knotData : String) : KNoTMessageRequestData {
+        val receivedJsonObject = JsonParser.parseString(knotData).asJsonObject
+        val id = receivedJsonObject.get(ID).asString
+        val sensorIdsJsonArray = receivedJsonObject.getAsJsonArray(SENSOR_IDS)
+        val sensorIds = mutableListOf<Int>()
+
+        sensorIdsJsonArray?.forEach {
+            sensorIds.add(it.asInt)
+        }
+
+        return KNoTMessageRequestData(id, sensorIds)
     }
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
@@ -6,6 +6,7 @@ import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_FLOAT
 import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_INT
 import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_MAX
 import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_RAW
+import com.cesar.knot_sdk.knot_messages.KNoTMessageAuthenticated
 import com.cesar.knot_sdk.knot_messages.KNoTMessageDataItem
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRequestData
 import com.cesar.knot_sdk.knot_messages.KNoTMessageSchemaResp
@@ -100,5 +101,13 @@ class KNoTMessageParser {
         val error = receivedJson.get(ERROR).toString()
 
         return KNoTMessageSchemaResp(id, error)
+    }
+
+    fun parseAuthStatus(knotAuth : String) : KNoTMessageAuthenticated {
+        val receivedJson = JsonParser.parseString(knotAuth).asJsonObject
+        val id = receivedJson.get(ID).asString
+        val error = receivedJson.get(ERROR).toString()
+
+        return KNoTMessageAuthenticated(id, error)
     }
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
@@ -9,6 +9,7 @@ import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_RAW
 import com.cesar.knot_sdk.knot_messages.KNoTMessageAuthenticated
 import com.cesar.knot_sdk.knot_messages.KNoTMessageDataItem
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRegistered
+import com.cesar.knot_sdk.knot_messages.KNoTMessageRemoved
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRequestData
 import com.cesar.knot_sdk.knot_messages.KNoTMessageSchemaResp
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateData
@@ -119,5 +120,13 @@ class KNoTMessageParser {
         val error = receivedJson.get(ERROR).toString()
 
         return KNoTMessageRegistered(id, token, error)
+    }
+
+    fun parseDeviceRemoved(knotRemove : String) : KNoTMessageRemoved {
+        val receivedJson = JsonParser.parseString(knotRemove).asJsonObject
+        val id = receivedJson.get(ID).asString
+        val error = receivedJson.get(ERROR).toString()
+
+        return KNoTMessageRemoved(id, error)
     }
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
@@ -8,6 +8,7 @@ import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_MAX
 import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_RAW
 import com.cesar.knot_sdk.knot_messages.KNoTMessageDataItem
 import com.cesar.knot_sdk.knot_messages.KNoTMessageRequestData
+import com.cesar.knot_sdk.knot_messages.KNoTMessageSchemaResp
 import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateData
 import com.google.gson.JsonParser
 
@@ -91,5 +92,13 @@ class KNoTMessageParser {
         }
 
         return KNoTMessageRequestData(id, sensorIds)
+    }
+
+    fun parseSchemaStatus(knotSchema : String) : KNoTMessageSchemaResp {
+        val receivedJson = JsonParser.parseString(knotSchema).asJsonObject
+        val id = receivedJson.get(ID).asString
+        val error = receivedJson.get(ERROR).toString()
+
+        return KNoTMessageSchemaResp(id, error)
     }
 }

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/KNoTMessageParser.kt
@@ -1,0 +1,78 @@
+package com.cesar.knot_sdk
+
+import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_NULL
+import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_BOOL
+import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_FLOAT
+import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_INT
+import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_MAX
+import com.cesar.knot_sdk.KNoTTypes.KNOT_VALUE_TYPE_RAW
+import com.cesar.knot_sdk.knot_messages.KNoTMessageDataItem
+import com.cesar.knot_sdk.knot_messages.KNoTMessageUpdateData
+import com.google.gson.JsonParser
+
+/**
+ * This class parses southbound traffic json requests in usable kotlin objects.
+ */
+class KNoTMessageParser {
+
+    private val sensorHash = mutableMapOf<Int, Int>()
+    private val VALUE = "value"
+    private val DATA = "data"
+    private val ID = "id"
+    private val SENSOR_ID = "sensorId"
+    private val ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE =
+            "The KNoTMessageParser is only prepared to handle " +
+            "KNOT_VALUE_TYPE_INT, KNOT_VALUE_TYPE_FLOAT, " +
+            "KNOT_VALUE_TYPE_BOOL, " + "KNOT_VALUE_TYPE_RAW, KNOT_VALUE_NULL."
+
+    private fun getSensorType(sensorId : Int) : Int {
+        val sensorType = sensorHash[sensorId]
+
+        if (sensorType == null) return KNOT_VALUE_NULL
+
+        return sensorType
+    }
+
+    fun addSensor(key : Int, value : Int) {
+        if (value >= KNOT_VALUE_TYPE_MAX) {
+            throw IllegalArgumentException(ILLEGAL_ARGUMENT_EXCEPTION_MESSAGE)
+        }
+        sensorHash[key] = value
+    }
+
+    fun parseDataUpdate(knotData : String) : KNoTMessageUpdateData {
+        val receivedJsonObject = JsonParser.parseString(knotData).asJsonObject
+        val id = receivedJsonObject.get(ID).asString
+        val dataJasonArray = receivedJsonObject.getAsJsonArray(DATA)
+        val data = mutableListOf<KNoTMessageDataItem>()
+        var type : Int
+        var sensorId : Int
+        dataJasonArray.forEach {
+            sensorId = it.asJsonObject.get(SENSOR_ID).asInt
+            type = getSensorType(sensorId)
+            when(type) {
+                KNOT_VALUE_TYPE_INT -> data.add(KNoTMessageDataItem(
+                    sensorId,
+                    it.asJsonObject.get(VALUE).asInt)
+                )
+
+                KNOT_VALUE_TYPE_FLOAT -> data.add(KNoTMessageDataItem(
+                    sensorId,
+                    it.asJsonObject.get(VALUE).asFloat)
+                )
+
+                KNOT_VALUE_TYPE_BOOL -> data.add(KNoTMessageDataItem(
+                    sensorId,
+                    it.asJsonObject.get(VALUE).asBoolean)
+                )
+
+                KNOT_VALUE_TYPE_RAW -> data.add(KNoTMessageDataItem(
+                    sensorId,
+                    it.asJsonObject.get(VALUE).asString)
+                )
+            }
+        }
+
+        return KNoTMessageUpdateData(id, data)
+    }
+}

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageAuthenticated.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageAuthenticated.kt
@@ -1,0 +1,11 @@
+package com.cesar.knot_sdk.knot_messages
+
+/**
+ * This is the class that deserialize the response of the authentication message.
+ * @property id the Thing unique identifier
+ * @property error an error message if the request fails
+ */
+data class KNoTMessageAuthenticated(
+    val id : String,
+    val error: String
+)

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageRegistered.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageRegistered.kt
@@ -4,8 +4,10 @@ package com.cesar.knot_sdk.knot_messages
  * This is the class that deserialize the response of the registration message.
  * @property id the Thing unique identifier
  * @property token the token received after registration
+ * @property error an error message if the request fails
  */
 data class KNoTMessageRegistered(
     val id : String,
-    val token : String
+    val token : String,
+    val error: String
 )

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageRemoved.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageRemoved.kt
@@ -1,0 +1,11 @@
+package com.cesar.knot_sdk.knot_messages
+
+/**
+ * This is the class that deserialize the response of the authentication message.
+ * @property id the Thing unique identifier
+ * @property error an error message if the request fails
+ */
+data class KNoTMessageRemoved(
+    val id : String,
+    val error: String
+)

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageRequestData.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageRequestData.kt
@@ -1,0 +1,11 @@
+package com.cesar.knot_sdk.knot_messages
+
+/**
+ * This is the class that deserialize the response of the authentication message.
+ * @property id the Thing unique identifier
+ * @property sensorIds a list with IDs of the sensor to send last value
+ */
+data class KNoTMessageRequestData(
+    val id : String,
+    val sensorIds: List<Int>?
+)

--- a/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageSchemaResp.kt
+++ b/knot-thing/src/main/java/com/cesar/knot_sdk/knot_messages/KNoTMessageSchemaResp.kt
@@ -1,0 +1,11 @@
+package com.cesar.knot_sdk.knot_messages
+
+/**
+ * This is the class that deserialize the response of the authentication message.
+ * @property id the Thing unique identifier
+ * @property error an error message if the request fails
+ */
+data class KNoTMessageSchemaResp(
+    val id : String,
+    val error : String
+)


### PR DESCRIPTION
Add parser for the following messages:
- Data Update
- Request Date
- Schema Status
- Device Auth Status
- Registered Device
- Device Removed

Depends on #13 